### PR TITLE
feat: add config, parsers, DLP, and clean backfill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/analysis/src/ingest.rs
+++ b/analysis/src/ingest.rs
@@ -1,6 +1,4 @@
-use crate::models::{
-    Dataset, ScoredTurn, SessionBundle, SessionSummary, TurnSummary,
-};
+use crate::models::{Dataset, ScoredTurn, SessionBundle, SessionSummary, TurnSummary};
 use crate::salience::{score_session, score_turn, tokenize};
 use anyhow::{Context, Result};
 use chrono::{NaiveDate, Utc};
@@ -118,14 +116,8 @@ pub fn load_dataset(log_path: &Path, day_filter: Option<NaiveDate>) -> Result<Da
             });
         }
 
-        let started_at = events
-            .first()
-            .map(|l| l.timestamp)
-            .unwrap_or_else(Utc::now);
-        let ended_at = events
-            .last()
-            .map(|l| l.timestamp)
-            .unwrap_or_else(Utc::now);
+        let started_at = events.first().map(|l| l.timestamp).unwrap_or_else(Utc::now);
+        let ended_at = events.last().map(|l| l.timestamp).unwrap_or_else(Utc::now);
 
         let project_context = pick_context(&project_context_counts).unwrap_or_else(|| {
             events

--- a/analysis/src/llm.rs
+++ b/analysis/src/llm.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use reqwest::Client;
 use serde_json::Value;
 use std::fs;

--- a/analysis/src/salience.rs
+++ b/analysis/src/salience.rs
@@ -15,7 +15,10 @@ pub fn score_turn(content: &str, role: &str, metadata: &serde_json::Value) -> (f
         score += 0.4;
         cues.push("question".to_string());
     }
-    if contains_any(&lower, &["error", "fail", "panic", "exception", "stack trace"]) {
+    if contains_any(
+        &lower,
+        &["error", "fail", "panic", "exception", "stack trace"],
+    ) {
         score += 0.3;
         cues.push("error".to_string());
     }
@@ -29,7 +32,11 @@ pub fn score_turn(content: &str, role: &str, metadata: &serde_json::Value) -> (f
     }
 
     if let Some(obj) = metadata.as_object() {
-        if obj.get("interrupted").and_then(|v| v.as_bool()).unwrap_or(false) {
+        if obj
+            .get("interrupted")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
             score += 0.5;
             cues.push("interrupted".to_string());
         }

--- a/core_daemon/src/main.rs
+++ b/core_daemon/src/main.rs
@@ -1,7 +1,9 @@
 use anyhow::Context;
+use scrapers::config::ContrailConfig;
 use scrapers::harvester::Harvester;
 use scrapers::log_writer::LogWriter;
 use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::task;
 
@@ -9,42 +11,62 @@ use tokio::task;
 async fn main() -> anyhow::Result<()> {
     println!("Starting Contrail Daemon...");
 
+    let config = ContrailConfig::from_env()?;
+
     // Phase 1: Create directory structure
-    let home = dirs::home_dir().context("Could not find home directory")?;
-    let contrail_dir = home.join(".contrail/logs");
-    fs::create_dir_all(&contrail_dir).context("Failed to create .contrail directory")?;
-    println!("Ensured .contrail directory exists at {:?}", contrail_dir);
+    let contrail_dir = config
+        .log_path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| config.log_path.clone());
+    fs::create_dir_all(&contrail_dir).context("Failed to create log directory")?;
+    println!(
+        "Ensured Contrail log directory exists at {:?}",
+        contrail_dir
+    );
 
-    let log_file = contrail_dir.join("master_log.jsonl");
-    let log_writer = LogWriter::new(log_file);
+    let log_writer = LogWriter::new(config.log_path.clone());
 
-    let harvester = Arc::new(Harvester::new(log_writer));
+    let enable_cursor = config.enable_cursor;
+    let enable_codex = config.enable_codex;
+    let enable_antigravity = config.enable_antigravity;
+    let enable_claude = config.enable_claude;
+
+    let harvester = Arc::new(Harvester::new(log_writer, config));
 
     let h1 = harvester.clone();
     let cursor_handle = task::spawn(async move {
-        if let Err(e) = h1.run_cursor_watcher().await {
-            eprintln!("Cursor Watcher failed: {:?}", e);
+        if enable_cursor {
+            if let Err(e) = h1.run_cursor_watcher().await {
+                eprintln!("Cursor Watcher failed: {:?}", e);
+            }
         }
     });
 
     let h2 = harvester.clone();
     let codex_handle = task::spawn(async move {
-        if let Err(e) = h2.run_codex_watcher().await {
-            eprintln!("Codex Watcher failed: {:?}", e);
+        if enable_codex {
+            if let Err(e) = h2.run_codex_watcher().await {
+                eprintln!("Codex Watcher failed: {:?}", e);
+            }
         }
     });
 
     let h3 = harvester.clone();
     let antigravity_handle = task::spawn(async move {
-        if let Err(e) = h3.run_antigravity_watcher().await {
-            eprintln!("Antigravity Watcher failed: {:?}", e);
+        if enable_antigravity {
+            if let Err(e) = h3.run_antigravity_watcher().await {
+                eprintln!("Antigravity Watcher failed: {:?}", e);
+            }
         }
     });
 
     let h4 = harvester.clone();
     let claude_handle = task::spawn(async move {
-        if let Err(e) = h4.run_claude_watcher().await {
-            eprintln!("Claude Watcher failed: {:?}", e);
+        if enable_claude {
+            if let Err(e) = h4.run_claude_watcher().await {
+                eprintln!("Claude Watcher failed: {:?}", e);
+            }
         }
     });
 

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -13,3 +13,4 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 scrapers = { path = "../scrapers" }
 anyhow = "1.0"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/importer/src/main.rs
+++ b/importer/src/main.rs
@@ -1,21 +1,26 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use chrono::Utc;
 use glob::glob;
+use scrapers::claude::parse_claude_line;
+use scrapers::codex::parse_codex_line;
+use scrapers::config::ContrailConfig;
 use scrapers::sentry::Sentry;
 use scrapers::types::{Interaction, MasterLog};
 use serde_json::Value;
+use std::collections::HashSet;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use uuid::Uuid;
+use xxhash_rust::xxh3::xxh3_64;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("✈️  Contrail History Importer");
     println!("Scanning for historical logs...");
 
-    let home = dirs::home_dir().context("Could not find home directory")?;
-    let log_file_path = home.join(".contrail/logs/master_log.jsonl");
+    let config = ContrailConfig::from_env()?;
+    let log_file_path = config.log_path.clone();
 
     // Open Master Log for appending
     let mut master_log = fs::OpenOptions::new()
@@ -26,14 +31,17 @@ async fn main() -> Result<()> {
     let mut count = 0;
 
     let sentry = Sentry::new();
+    let mut existing_keys = load_existing_keys(&log_file_path)?;
 
     // 1. Import Codex Sessions
-    let codex_pattern = home.join(".codex/sessions/**/*.jsonl");
+    let codex_pattern = config.codex_root.join("**/*.jsonl");
     if let Some(pattern_str) = codex_pattern.to_str() {
         for entry in glob(pattern_str)? {
             match entry {
                 Ok(path) => {
-                    if let Ok(c) = import_codex_file(&path, &mut master_log, &sentry) {
+                    if let Ok(c) =
+                        import_codex_file(&path, &mut master_log, &sentry, &mut existing_keys)
+                    {
                         count += c;
                     }
                 }
@@ -43,64 +51,71 @@ async fn main() -> Result<()> {
     }
 
     // 2. Import Claude History
-    let claude_path = home.join(".claude/history.jsonl");
-    if claude_path.exists() {
-        if let Ok(c) = import_claude_file(&claude_path, &mut master_log, &sentry) {
-            count += c;
-        }
+    let claude_path = config.claude_history.clone();
+    if claude_path.exists()
+        && let Ok(c) =
+            import_claude_file(&claude_path, &mut master_log, &sentry, &mut existing_keys)
+    {
+        count += c;
     }
 
     println!("✅ Import complete! Imported {} events.", count);
     Ok(())
 }
 
-fn import_codex_file(path: &Path, writer: &mut fs::File, sentry: &Sentry) -> Result<usize> {
+fn import_codex_file(
+    path: &Path,
+    writer: &mut fs::File,
+    sentry: &Sentry,
+    existing: &mut HashSet<String>,
+) -> Result<usize> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut count = 0;
 
     for line in reader.lines() {
         let line = line?;
-        let parsed =
-            serde_json::from_str::<Value>(&line).unwrap_or_else(|_| Value::String(line.clone()));
-        let (content, flags) = sentry.scan_and_redact(&line);
-        let timestamp = extract_timestamp(&parsed).unwrap_or_else(Utc::now);
-
         let mut metadata = serde_json::Map::new();
         metadata.insert("imported".to_string(), serde_json::Value::Bool(true));
-        if let Some(model) = parsed
-            .get("payload")
-            .and_then(|p| p.get("model"))
-            .and_then(|m| m.as_str())
+
+        let mut role = "assistant".to_string();
+        let mut content = line.clone();
+        let mut project_context = "Imported History".to_string();
+        let mut timestamp = None;
+
+        if let Some(parsed) = parse_codex_line(&line) {
+            role = parsed.role;
+            content = parsed.content;
+            timestamp = parsed.timestamp;
+            if let Some(ctx) = parsed.project_context {
+                project_context = ctx.clone();
+            }
+            for (k, v) in parsed.metadata {
+                metadata.insert(k, v);
+            }
+        } else if let Ok(parsed) = serde_json::from_str::<Value>(&line)
+            && let Some(ts) = extract_timestamp(&parsed)
         {
-            metadata.insert(
-                "model".to_string(),
-                serde_json::Value::String(model.to_string()),
-            );
+            timestamp = Some(ts);
         }
-        if let Some(cwd) = parsed
-            .get("payload")
-            .and_then(|p| p.get("cwd"))
-            .and_then(|c| c.as_str())
-        {
-            metadata.insert(
-                "cwd".to_string(),
-                serde_json::Value::String(cwd.to_string()),
-            );
+
+        let (content, flags) = sentry.scan_and_redact(&content);
+
+        let session_id = path.file_name().unwrap().to_str().unwrap().to_string();
+        let key = dedupe_key("codex-cli", &session_id, &content);
+        if existing.contains(&key) {
+            continue;
         }
+        existing.insert(key);
 
         let log = MasterLog {
             event_id: Uuid::new_v4(),
-            timestamp,
+            timestamp: timestamp.unwrap_or_else(Utc::now),
             source_tool: "codex-cli".to_string(),
-            project_context: metadata
-                .get("cwd")
-                .and_then(|c| c.as_str())
-                .unwrap_or("Imported History")
-                .to_string(),
-            session_id: path.file_name().unwrap().to_str().unwrap().to_string(),
+            project_context,
+            session_id,
             interaction: Interaction {
-                role: "assistant".to_string(),
+                role,
                 content,
                 artifacts: None,
             },
@@ -116,35 +131,69 @@ fn import_codex_file(path: &Path, writer: &mut fs::File, sentry: &Sentry) -> Res
     Ok(count)
 }
 
-fn import_claude_file(path: &Path, writer: &mut fs::File, sentry: &Sentry) -> Result<usize> {
+fn import_claude_file(
+    path: &Path,
+    writer: &mut fs::File,
+    sentry: &Sentry,
+    existing: &mut HashSet<String>,
+) -> Result<usize> {
     let file = fs::File::open(path)?;
     let reader = BufReader::new(file);
     let mut count = 0;
 
     for line in reader.lines() {
         let line = line?;
-        let parsed =
-            serde_json::from_str::<Value>(&line).unwrap_or_else(|_| Value::String(line.clone()));
-        let (content, flags) = sentry.scan_and_redact(&line);
-        let timestamp = extract_timestamp(&parsed).unwrap_or_else(Utc::now);
+        let mut metadata = serde_json::Map::new();
+        metadata.insert("imported".to_string(), serde_json::Value::Bool(true));
+
+        let mut role = "user_or_assistant".to_string();
+        let mut content = line.clone();
+        let mut project_context = "Claude Global".to_string();
+        let mut session_id = "history".to_string();
+        let mut timestamp = None;
+
+        if let Some(parsed) = parse_claude_line(&line) {
+            role = parsed.role;
+            content = parsed.content;
+            timestamp = parsed.timestamp;
+            let parsed_session_id = parsed.session_id.clone();
+            if let Some(id) = parsed_session_id.as_ref() {
+                session_id = id.clone();
+            }
+            if let Some(ctx) = parsed.project_context {
+                project_context = ctx;
+            } else if let Some(id) = parsed_session_id {
+                project_context = id;
+            }
+            for (k, v) in parsed.metadata {
+                metadata.insert(k, v);
+            }
+        } else if let Ok(parsed) = serde_json::from_str::<Value>(&line)
+            && let Some(ts) = extract_timestamp(&parsed)
+        {
+            timestamp = Some(ts);
+        }
+
+        let (content, flags) = sentry.scan_and_redact(&content);
+        let key = dedupe_key("claude-code", &session_id, &content);
+        if existing.contains(&key) {
+            continue;
+        }
+        existing.insert(key);
 
         let log = MasterLog {
             event_id: Uuid::new_v4(),
-            timestamp,
+            timestamp: timestamp.unwrap_or_else(Utc::now),
             source_tool: "claude-code".to_string(),
-            project_context: parsed
-                .get("conversation_id")
-                .and_then(|c| c.as_str())
-                .unwrap_or("Claude Global")
-                .to_string(),
-            session_id: "history".to_string(),
+            project_context,
+            session_id,
             interaction: Interaction {
-                role: "user_or_assistant".to_string(),
+                role,
                 content,
                 artifacts: None,
             },
             security_flags: flags,
-            metadata: serde_json::json!({ "imported": true }),
+            metadata: serde_json::Value::Object(metadata),
         };
 
         if log.validate_schema().is_ok() {
@@ -162,10 +211,10 @@ fn extract_timestamp(value: &Value) -> Option<chrono::DateTime<Utc>> {
         .or_else(|| value.get("createdAt"))
         .and_then(|v| v.as_str());
 
-    if let Some(ts) = as_str {
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
-            return Some(dt.with_timezone(&Utc));
-        }
+    if let Some(ts) = as_str
+        && let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts)
+    {
+        return Some(dt.with_timezone(&Utc));
     }
 
     if let Some(ts) = value
@@ -178,4 +227,36 @@ fn extract_timestamp(value: &Value) -> Option<chrono::DateTime<Utc>> {
     }
 
     None
+}
+
+fn load_existing_keys(path: &Path) -> Result<HashSet<String>> {
+    let mut keys = HashSet::new();
+    if !path.exists() {
+        return Ok(keys);
+    }
+    let file = fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        if let Ok(json) = serde_json::from_str::<Value>(&line) {
+            let source = json
+                .get("source_tool")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let session = json.get("session_id").and_then(Value::as_str).unwrap_or("");
+            let content = json
+                .pointer("/interaction/content")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if !source.is_empty() && !session.is_empty() {
+                keys.insert(dedupe_key(source, session, content));
+            }
+        }
+    }
+    Ok(keys)
+}
+
+fn dedupe_key(source: &str, session: &str, content: &str) -> String {
+    let hash = xxh3_64(content.as_bytes());
+    format!("{source}:{session}:{hash}")
 }

--- a/scrapers/src/claude.rs
+++ b/scrapers/src/claude.rs
@@ -1,0 +1,200 @@
+use crate::parse::{extract_text, parse_timestamp_value};
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone)]
+pub struct ParsedLine {
+    pub role: String,
+    pub content: String,
+    pub timestamp: Option<DateTime<Utc>>,
+    pub session_id: Option<String>,
+    pub project_context: Option<String>,
+    pub metadata: Map<String, Value>,
+}
+
+pub fn parse_claude_line(raw: &str) -> Option<ParsedLine> {
+    let json = serde_json::from_str::<Value>(raw).ok()?;
+    let mut metadata = Map::new();
+
+    let session_id = json
+        .get("conversation_id")
+        .or_else(|| json.get("conversationId"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_string());
+    if let Some(id) = session_id.as_ref() {
+        metadata.insert("conversation_id".to_string(), Value::String(id.clone()));
+    }
+
+    if let Some(model) = json.get("model").and_then(Value::as_str) {
+        metadata.insert("model".to_string(), Value::String(model.to_string()));
+    }
+
+    if let Some(usage) = json.get("usage") {
+        append_usage(&mut metadata, usage);
+    }
+    if let Some(metrics) = json.get("metrics") {
+        append_metrics(&mut metadata, metrics);
+    }
+
+    let project_context = extract_cwd(&json);
+    if let Some(cwd) = project_context.as_ref() {
+        metadata.insert("cwd".to_string(), Value::String(cwd.clone()));
+    }
+
+    let timestamp = json
+        .get("timestamp")
+        .or_else(|| json.get("created_at"))
+        .or_else(|| json.get("createdAt"))
+        .and_then(parse_timestamp_value);
+    if let Some(ts) = timestamp.as_ref() {
+        metadata.insert(
+            "original_timestamp".to_string(),
+            Value::String(ts.to_rfc3339()),
+        );
+    }
+
+    let role = json
+        .get("role")
+        .and_then(Value::as_str)
+        .unwrap_or("user_or_assistant")
+        .to_string();
+
+    let content_value = json
+        .get("content")
+        .or_else(|| json.pointer("/message/content"))
+        .or_else(|| json.pointer("/payload/content"));
+
+    let content = content_value
+        .and_then(extract_text)
+        .unwrap_or_else(|| raw.to_string());
+
+    if content.trim().is_empty() {
+        return None;
+    }
+
+    Some(ParsedLine {
+        role,
+        content,
+        timestamp,
+        session_id,
+        project_context,
+        metadata,
+    })
+}
+
+fn append_usage(meta: &mut Map<String, Value>, value: &Value) {
+    if let Some(obj) = value.as_object() {
+        for (k, v) in obj {
+            match k.as_str() {
+                "total" | "total_tokens" | "totalTokens" => {
+                    insert_scalar(meta, "usage_total_tokens", v)
+                }
+                "prompt" | "prompt_tokens" | "promptTokens" | "input" => {
+                    insert_scalar(meta, "usage_prompt_tokens", v)
+                }
+                "completion" | "completion_tokens" | "completionTokens" | "output" => {
+                    insert_scalar(meta, "usage_completion_tokens", v)
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn append_metrics(meta: &mut Map<String, Value>, value: &Value) {
+    if let Some(obj) = value.as_object() {
+        for (k, v) in obj {
+            match k.as_str() {
+                "latency" | "latencyMs" | "latency_ms" => insert_scalar(meta, "latency_ms", v),
+                "duration" | "durationMs" | "duration_ms" => insert_scalar(meta, "duration_ms", v),
+                "wallTime" | "wall_time_ms" => insert_scalar(meta, "wall_time_ms", v),
+                _ => {}
+            }
+        }
+    }
+}
+
+fn insert_scalar(meta: &mut Map<String, Value>, key: &str, value: &Value) {
+    match value {
+        Value::String(s) => {
+            meta.insert(key.to_string(), Value::String(s.clone()));
+        }
+        Value::Number(n) => {
+            meta.insert(key.to_string(), Value::Number(n.clone()));
+        }
+        Value::Bool(b) => {
+            meta.insert(key.to_string(), Value::Bool(*b));
+        }
+        _ => {}
+    }
+}
+
+fn extract_cwd(json: &Value) -> Option<String> {
+    let candidate_keys = [
+        "cwd",
+        "working_dir",
+        "workdir",
+        "project_root",
+        "path",
+        "root",
+    ];
+
+    if let Some(obj) = json.as_object() {
+        for key in candidate_keys {
+            if let Some(val) = obj.get(key).and_then(|v| v.as_str()) {
+                if looks_like_path(val) {
+                    return Some(val.to_string());
+                }
+            }
+        }
+        if let Some(tool_use) = obj.get("tool_use").and_then(|v| v.as_object()) {
+            if let Some(args) = tool_use.get("arguments").and_then(|v| v.as_str()) {
+                if let Some(pos) = args.find("/Users/") {
+                    let snippet = &args[pos..];
+                    if let Some(end) = snippet.find('"') {
+                        let path = &snippet[..end];
+                        if looks_like_path(path) {
+                            return Some(path.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn looks_like_path(val: &str) -> bool {
+    val.starts_with('/') && val.len() > 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_claude_line() {
+        let raw = r#"{
+            "created_at": "2025-12-01T10:00:00Z",
+            "conversation_id": "conv-1",
+            "role": "user",
+            "content": "hi",
+            "cwd": "/tmp/project",
+            "usage": { "totalTokens": 3 }
+        }"#;
+
+        let parsed = parse_claude_line(raw).expect("should parse");
+        assert_eq!(parsed.role, "user");
+        assert_eq!(parsed.content, "hi");
+        assert_eq!(parsed.session_id.as_deref(), Some("conv-1"));
+        assert_eq!(parsed.project_context.as_deref(), Some("/tmp/project"));
+        assert!(parsed.timestamp.is_some());
+        assert_eq!(
+            parsed
+                .metadata
+                .get("usage_total_tokens")
+                .and_then(Value::as_i64),
+            Some(3)
+        );
+    }
+}

--- a/scrapers/src/codex.rs
+++ b/scrapers/src/codex.rs
@@ -1,0 +1,171 @@
+use crate::parse::{extract_text, parse_timestamp_value};
+use chrono::{DateTime, Utc};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone)]
+pub struct ParsedLine {
+    pub role: String,
+    pub content: String,
+    pub timestamp: Option<DateTime<Utc>>,
+    pub project_context: Option<String>,
+    pub metadata: Map<String, Value>,
+}
+
+pub fn parse_codex_line(raw: &str) -> Option<ParsedLine> {
+    let json = serde_json::from_str::<Value>(raw).ok()?;
+    let mut metadata = Map::new();
+
+    let project_context = json
+        .pointer("/payload/cwd")
+        .or_else(|| json.pointer("/turn_context/cwd"))
+        .or_else(|| json.pointer("/cwd"))
+        .and_then(Value::as_str)
+        .map(|s| s.to_string());
+
+    if let Some(cwd) = project_context.as_ref() {
+        metadata.insert("cwd".to_string(), Value::String(cwd.clone()));
+    }
+
+    if let Some(model) = json.pointer("/payload/model").and_then(Value::as_str) {
+        metadata.insert("model".to_string(), Value::String(model.to_string()));
+    }
+
+    if let Some(info) = json.pointer("/payload/info") {
+        append_usage(&mut metadata, info);
+    }
+    if let Some(usage) = json.pointer("/payload/usage") {
+        append_usage(&mut metadata, usage);
+    }
+    if let Some(metrics) = json.pointer("/payload/metrics") {
+        append_metrics(&mut metadata, metrics);
+    }
+    if let Some(metrics) = json.pointer("/metrics") {
+        append_metrics(&mut metadata, metrics);
+    }
+
+    let timestamp = json
+        .get("timestamp")
+        .or_else(|| json.get("created_at"))
+        .or_else(|| json.get("createdAt"))
+        .and_then(parse_timestamp_value);
+    if let Some(ts) = timestamp.as_ref() {
+        metadata.insert(
+            "original_timestamp".to_string(),
+            Value::String(ts.to_rfc3339()),
+        );
+    }
+
+    let role = json
+        .pointer("/interaction/role")
+        .or_else(|| json.pointer("/payload/message/role"))
+        .or_else(|| json.pointer("/payload/role"))
+        .or_else(|| json.pointer("/role"))
+        .and_then(Value::as_str)
+        .unwrap_or("assistant")
+        .to_string();
+
+    let content_value = json
+        .pointer("/interaction/content")
+        .or_else(|| json.pointer("/payload/message/content"))
+        .or_else(|| json.pointer("/payload/content"))
+        .or_else(|| json.pointer("/message/content"))
+        .or_else(|| json.get("content"));
+
+    let content = content_value
+        .and_then(extract_text)
+        .unwrap_or_else(|| raw.to_string());
+
+    if content.trim().is_empty() {
+        return None;
+    }
+
+    Some(ParsedLine {
+        role,
+        content,
+        timestamp,
+        project_context,
+        metadata,
+    })
+}
+
+fn append_usage(meta: &mut Map<String, Value>, value: &Value) {
+    if let Some(obj) = value.as_object() {
+        for (k, v) in obj {
+            match k.as_str() {
+                "total" | "total_tokens" | "totalTokens" => {
+                    insert_scalar(meta, "usage_total_tokens", v)
+                }
+                "prompt" | "prompt_tokens" | "promptTokens" | "input" => {
+                    insert_scalar(meta, "usage_prompt_tokens", v)
+                }
+                "completion" | "completion_tokens" | "completionTokens" | "output" => {
+                    insert_scalar(meta, "usage_completion_tokens", v)
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn append_metrics(meta: &mut Map<String, Value>, value: &Value) {
+    if let Some(obj) = value.as_object() {
+        for (k, v) in obj {
+            match k.as_str() {
+                "latency" | "latencyMs" | "latency_ms" => insert_scalar(meta, "latency_ms", v),
+                "duration" | "durationMs" | "duration_ms" => insert_scalar(meta, "duration_ms", v),
+                "wallTime" | "wall_time_ms" => insert_scalar(meta, "wall_time_ms", v),
+                _ => {}
+            }
+        }
+    }
+}
+
+fn insert_scalar(meta: &mut Map<String, Value>, key: &str, value: &Value) {
+    match value {
+        Value::String(s) => {
+            meta.insert(key.to_string(), Value::String(s.clone()));
+        }
+        Value::Number(n) => {
+            meta.insert(key.to_string(), Value::Number(n.clone()));
+        }
+        Value::Bool(b) => {
+            meta.insert(key.to_string(), Value::Bool(*b));
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_codex_line() {
+        let raw = r#"{
+            "timestamp": "2025-12-01T10:00:00Z",
+            "payload": {
+                "cwd": "/tmp/project",
+                "model": "gpt-5",
+                "message": { "role": "assistant", "content": "hello" },
+                "info": { "totalTokens": 10 }
+            }
+        }"#;
+
+        let parsed = parse_codex_line(raw).expect("should parse");
+        assert_eq!(parsed.role, "assistant");
+        assert_eq!(parsed.content, "hello");
+        assert_eq!(parsed.project_context.as_deref(), Some("/tmp/project"));
+        assert!(parsed.timestamp.is_some());
+        assert_eq!(
+            parsed.metadata.get("model").and_then(Value::as_str),
+            Some("gpt-5")
+        );
+        assert_eq!(
+            parsed
+                .metadata
+                .get("usage_total_tokens")
+                .and_then(Value::as_i64),
+            Some(10)
+        );
+    }
+}

--- a/scrapers/src/config.rs
+++ b/scrapers/src/config.rs
@@ -1,0 +1,85 @@
+use anyhow::{Context, Result};
+use std::env;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub struct ContrailConfig {
+    pub log_path: PathBuf,
+    pub cursor_storage: PathBuf,
+    pub codex_root: PathBuf,
+    pub claude_history: PathBuf,
+    pub antigravity_brain: PathBuf,
+    pub enable_cursor: bool,
+    pub enable_codex: bool,
+    pub enable_claude: bool,
+    pub enable_antigravity: bool,
+    pub cursor_silence_secs: u64,
+    pub codex_silence_secs: u64,
+    pub claude_silence_secs: u64,
+}
+
+impl ContrailConfig {
+    pub fn from_env() -> Result<Self> {
+        let home = dirs::home_dir().context("could not resolve home directory")?;
+        let log_default = home.join(".contrail/logs/master_log.jsonl");
+
+        Ok(Self {
+            log_path: env_path("CONTRAIL_LOG_PATH", log_default, home.as_path()),
+            cursor_storage: env_path(
+                "CONTRAIL_CURSOR_STORAGE",
+                home.join("Library/Application Support/Cursor/User/workspaceStorage"),
+                home.as_path(),
+            ),
+            codex_root: env_path(
+                "CONTRAIL_CODEX_ROOT",
+                home.join(".codex/sessions"),
+                home.as_path(),
+            ),
+            claude_history: env_path(
+                "CONTRAIL_CLAUDE_HISTORY",
+                home.join(".claude/history.jsonl"),
+                home.as_path(),
+            ),
+            antigravity_brain: env_path(
+                "CONTRAIL_ANTIGRAVITY_BRAIN",
+                home.join(".gemini/antigravity/brain"),
+                home.as_path(),
+            ),
+            enable_cursor: env_bool("CONTRAIL_ENABLE_CURSOR", true),
+            enable_codex: env_bool("CONTRAIL_ENABLE_CODEX", true),
+            enable_claude: env_bool("CONTRAIL_ENABLE_CLAUDE", true),
+            enable_antigravity: env_bool("CONTRAIL_ENABLE_ANTIGRAVITY", true),
+            cursor_silence_secs: env_u64("CONTRAIL_CURSOR_SILENCE_SECS", 5),
+            codex_silence_secs: env_u64("CONTRAIL_CODEX_SILENCE_SECS", 3),
+            claude_silence_secs: env_u64("CONTRAIL_CLAUDE_SILENCE_SECS", 5),
+        })
+    }
+}
+
+fn env_path(key: &str, default: PathBuf, home: &std::path::Path) -> PathBuf {
+    match env::var(key) {
+        Ok(val) if !val.trim().is_empty() => expand_tilde(&val, home),
+        _ => default,
+    }
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match env::var(key) {
+        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Err(_) => default,
+    }
+}
+
+fn env_u64(key: &str, default: u64) -> u64 {
+    match env::var(key) {
+        Ok(val) => val.parse::<u64>().unwrap_or(default),
+        Err(_) => default,
+    }
+}
+
+fn expand_tilde(input: &str, home: &std::path::Path) -> PathBuf {
+    if let Some(rest) = input.strip_prefix("~/") {
+        return home.join(rest);
+    }
+    PathBuf::from(input)
+}

--- a/scrapers/src/lib.rs
+++ b/scrapers/src/lib.rs
@@ -1,6 +1,10 @@
+pub mod claude;
+pub mod codex;
+pub mod config;
 pub mod cursor;
 pub mod harvester;
 pub mod log_writer;
 pub mod notifier;
+pub mod parse;
 pub mod sentry;
 pub mod types;

--- a/scrapers/src/notifier.rs
+++ b/scrapers/src/notifier.rs
@@ -15,3 +15,9 @@ impl Notifier {
             .show();
     }
 }
+
+impl Default for Notifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/scrapers/src/parse.rs
+++ b/scrapers/src/parse.rs
@@ -1,0 +1,81 @@
+use chrono::{DateTime, TimeZone, Utc};
+use serde_json::Value;
+
+pub fn extract_text(value: &Value) -> Option<String> {
+    extract_text_depth(value, 0)
+}
+
+fn extract_text_depth(value: &Value, depth: usize) -> Option<String> {
+    if depth > 6 {
+        return None;
+    }
+    match value {
+        Value::String(s) => Some(s.to_string()),
+        Value::Array(items) => {
+            let mut parts = Vec::new();
+            for item in items {
+                if let Some(text) = extract_text_depth(item, depth + 1) {
+                    if !text.trim().is_empty() {
+                        parts.push(text);
+                    }
+                }
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join(""))
+            }
+        }
+        Value::Object(map) => {
+            for key in [
+                "content",
+                "text",
+                "message",
+                "delta",
+                "completion",
+                "prompt",
+            ] {
+                if let Some(v) = map.get(key) {
+                    if let Some(text) = extract_text_depth(v, depth + 1) {
+                        if !text.trim().is_empty() {
+                            return Some(text);
+                        }
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+pub fn parse_timestamp_value(value: &Value) -> Option<DateTime<Utc>> {
+    match value {
+        Value::String(s) => parse_timestamp_str(s),
+        Value::Number(n) => n.as_i64().and_then(parse_timestamp_i64),
+        _ => None,
+    }
+}
+
+pub fn parse_timestamp_str(raw: &str) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(num) = raw.parse::<i64>() {
+        return parse_timestamp_i64(num);
+    }
+    None
+}
+
+pub fn parse_timestamp_i64(num: i64) -> Option<DateTime<Utc>> {
+    if num <= 0 {
+        return None;
+    }
+    // Heuristic: treat values over ~year 2286 seconds as milliseconds.
+    if num > 10_000_000_000 {
+        let secs = num / 1000;
+        let nsec = ((num % 1000) * 1_000_000) as u32;
+        return Utc.timestamp_opt(secs, nsec).single();
+    }
+    Utc.timestamp_opt(num, 0).single()
+}

--- a/scrapers/src/sentry.rs
+++ b/scrapers/src/sentry.rs
@@ -2,19 +2,42 @@ use crate::types::SecurityFlags;
 use regex::Regex;
 
 pub struct Sentry {
-    secret_patterns: Vec<Regex>,
+    patterns: Vec<(&'static str, Regex)>,
 }
 
 impl Sentry {
     pub fn new() -> Self {
-        // Basic patterns for demo
+        // Basic but broader patterns; labels are surfaced in redacted_secrets.
         let patterns = vec![
-            Regex::new(r"sk-[a-zA-Z0-9]{20,}").unwrap(), // OpenAI-ish
-            Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),    // AWS
+            ("openai_key", Regex::new(r"sk-[a-zA-Z0-9]{20,}").unwrap()),
+            (
+                "openai_proj_key",
+                Regex::new(r"sk-proj-[a-zA-Z0-9]{20,}").unwrap(),
+            ),
+            (
+                "anthropic_key",
+                Regex::new(r"sk-ant-[a-zA-Z0-9_-]{20,}").unwrap(),
+            ),
+            (
+                "github_token",
+                Regex::new(r"gh[pousr]_[a-zA-Z0-9]{20,}").unwrap(),
+            ),
+            (
+                "slack_token",
+                Regex::new(r"xox[baprs]-[a-zA-Z0-9-]{10,}").unwrap(),
+            ),
+            ("aws_access_key", Regex::new(r"AKIA[0-9A-Z]{16}").unwrap()),
+            (
+                "jwt",
+                Regex::new(r"eyJ[a-zA-Z0-9_-]{10,}\\.[a-zA-Z0-9_-]{10,}\\.[a-zA-Z0-9_-]{10,}")
+                    .unwrap(),
+            ),
+            (
+                "email",
+                Regex::new(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}").unwrap(),
+            ),
         ];
-        Self {
-            secret_patterns: patterns,
-        }
+        Self { patterns }
     }
 
     pub fn scan_and_redact(&self, content: &str) -> (String, SecurityFlags) {
@@ -22,14 +45,13 @@ impl Sentry {
         let mut detected_secrets = Vec::new();
         let mut has_pii = false;
 
-        for pattern in &self.secret_patterns {
-            if pattern.is_match(content) {
-                has_pii = true; // Treating secrets as sensitive
-                                // Redact
+        for (label, pattern) in &self.patterns {
+            if pattern.is_match(&redacted_content) {
+                has_pii = true;
                 redacted_content = pattern
-                    .replace_all(&redacted_content, "[REDACTED_SECRET]")
+                    .replace_all(&redacted_content, "[REDACTED]")
                     .to_string();
-                detected_secrets.push("SECRET_DETECTED".to_string());
+                detected_secrets.push(label.to_string());
             }
         }
 
@@ -40,5 +62,11 @@ impl Sentry {
                 redacted_secrets: detected_secrets,
             },
         )
+    }
+}
+
+impl Default for Sentry {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
Summary:\n- Added env-driven Contrail config and per-tool toggles.\n- Improved live + historical parsing for Codex/Claude with real roles/timestamps, Cursor timestamp extraction, and Antigravity delta capture.\n- Expanded DLP patterns and labeled redactions.\n- Historical importer now dedupes and uses new parsers.\n\nTests:\n- cargo fmt\n- cargo check\n- cargo test\n- cargo clippy -p scrapers -p core_daemon -p importer --all-targets -- -D warnings\n\nNotes:\n- Workspace-wide strict clippy still reports pre-existing lints in decoder/exporter.