### PR TITLE
fix(memex): resolve clippy dead_code in detect

### DIFF
--- a/tools/memex/src/detect.rs
+++ b/tools/memex/src/detect.rs
@@ -206,10 +206,6 @@ pub fn cursor_workspace_storage() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join("Library/Application Support/Cursor/User/workspaceStorage"))
 }
 
-pub fn codex_sessions_root() -> Option<PathBuf> {
-    codex_sessions_roots().into_iter().next()
-}
-
 pub fn codex_sessions_roots() -> Vec<PathBuf> {
     dirs::home_dir()
         .map(|h| codex_sessions_roots_from_home(&h))


### PR DESCRIPTION
## Summary
- remove unused `codex_sessions_root()` helper in `tools/memex/src/detect.rs`

## Why
- CI runs clippy with `-D warnings`; the unused function failed both linux and macOS jobs.

## Testing
- Not run locally (not requested)
