### PR TITLE
fix: harden memex compact prompt wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "analysis"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "contrail-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "importer",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "contrail-dashboard"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-stream",
  "axum",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "contrail-memex"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "age",
  "anyhow",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "contrail-types"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "contrails"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "analysis",
  "anyhow",
@@ -738,7 +738,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core_daemon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "exporter"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "importer"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2932,7 +2932,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrapers"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "arboard",
@@ -4339,7 +4339,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wrapup"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "analysis"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Contrail analysis UI and scoring service"
 license = "MIT"
@@ -10,10 +10,10 @@ repository = "https://github.com/strangeloopcanon/contrail"
 anyhow = "1.0"
 axum = "0.7.5"
 chrono = { version = "0.4", features = ["serde"] }
-contrail-types = { path = "../contrail_types", version = "0.1.3" }
+contrail-types = { path = "../contrail_types", version = "0.1.4" }
 dirs = "5.0.1"
 regex = "1.10.4"
-scrapers = { path = "../scrapers", version = "0.1.4" }
+scrapers = { path = "../scrapers", version = "0.1.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/contrail_types/Cargo.toml
+++ b/contrail_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contrail-types"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Shared Contrail log schema and protocol types"
 license = "MIT"

--- a/contrails/Cargo.toml
+++ b/contrails/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contrails"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "All-in-one installer for Contrail: local-first flight recorder for AI coding sessions"
 license = "MIT"
@@ -39,13 +39,13 @@ name = "wrapup"
 path = "src/bin/wrapup.rs"
 
 [dependencies]
-contrail-cli = { path = "../tools/contrail", version = "0.1.4" }
-contrail-memex = { path = "../tools/memex", version = "0.1.3" }
-core_daemon = { path = "../core_daemon", version = "0.1.3" }
-contrail-dashboard = { path = "../dashboard", version = "0.1.3" }
-analysis = { path = "../analysis", version = "0.1.3" }
-importer = { path = "../importer", version = "0.1.4" }
-exporter = { path = "../tools/exporter", version = "0.1.3" }
-wrapup = { path = "../tools/wrapup", version = "0.1.3" }
+contrail-cli = { path = "../tools/contrail", version = "0.1.5" }
+contrail-memex = { path = "../tools/memex", version = "0.1.4" }
+core_daemon = { path = "../core_daemon", version = "0.1.4" }
+contrail-dashboard = { path = "../dashboard", version = "0.1.4" }
+analysis = { path = "../analysis", version = "0.1.4" }
+importer = { path = "../importer", version = "0.1.5" }
+exporter = { path = "../tools/exporter", version = "0.1.4" }
+wrapup = { path = "../tools/wrapup", version = "0.1.4" }
 anyhow = "1.0"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/core_daemon/Cargo.toml
+++ b/core_daemon/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "core_daemon"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Contrail daemon for passive local session capture"
 license = "MIT"
 repository = "https://github.com/strangeloopcanon/contrail"
 
 [dependencies]
-scrapers = { path = "../scrapers", version = "0.1.4" }
+scrapers = { path = "../scrapers", version = "0.1.5" }
 tokio = { version = "1.37.0", features = ["full"] }
 anyhow = "1.0"
 tracing = "0.1"

--- a/dashboard/Cargo.toml
+++ b/dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contrail-dashboard"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Contrail dashboard web UI for local-first session logs"
 license = "MIT"
@@ -20,4 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tower-http = { version = "0.5.2", features = ["fs", "trace", "cors"] }
 dirs = "5.0.1"
-scrapers = { path = "../scrapers", version = "0.1.4" } # Reuse types
+scrapers = { path = "../scrapers", version = "0.1.5" } # Reuse types

--- a/importer/Cargo.toml
+++ b/importer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "importer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Contrail history import and cross-machine log merge/export library + CLI"
 license = "MIT"
 repository = "https://github.com/strangeloopcanon/contrail"
 
 [dependencies]
-scrapers = { path = "../scrapers", version = "0.1.4" }
+scrapers = { path = "../scrapers", version = "0.1.5" }
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }

--- a/scrapers/Cargo.toml
+++ b/scrapers/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scrapers"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Contrail scrapers and normalization library for local AI coding session logs"
 license = "MIT"
 repository = "https://github.com/strangeloopcanon/contrail"
 
 [dependencies]
-contrail-types = { path = "../contrail_types", version = "0.1.3" }
+contrail-types = { path = "../contrail_types", version = "0.1.4" }
 notify = "6.1.1"
 notify-debouncer-full = "0.3.1"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/tools/contrail/Cargo.toml
+++ b/tools/contrail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contrail-cli"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "Contrail CLI: service lifecycle plus history import and cross-machine export/merge"
 license = "MIT"
@@ -12,4 +12,4 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-importer = { path = "../../importer", version = "0.1.4" }
+importer = { path = "../../importer", version = "0.1.5" }

--- a/tools/exporter/Cargo.toml
+++ b/tools/exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exporter"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Contrail exporter for filtered JSONL datasets"
 license = "MIT"

--- a/tools/memex/Cargo.toml
+++ b/tools/memex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contrail-memex"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Self-managed context layer for coding agents"
 license = "MIT"
@@ -11,7 +11,7 @@ name = "memex"
 path = "src/main.rs"
 
 [dependencies]
-scrapers = { path = "../../scrapers", version = "0.1.4" }
+scrapers = { path = "../../scrapers", version = "0.1.5" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tools/memex/README.md
+++ b/tools/memex/README.md
@@ -47,13 +47,14 @@ What it writes depends on which agents have been used in this repo (auto-detecte
 
 | Agent | File created | What it does |
 |-------|-------------|--------------|
-| Codex | Appends to `AGENTS.md`, writes `.codex/config.toml` | Points Codex at the context folder and compact prompt |
+| Codex | Appends to `AGENTS.md`, writes `.codex/config.toml` + `.codex/compact_prompt.md` | Points Codex at a repo-local compact prompt |
 | Claude Code | Creates/appends to `CLAUDE.md` | Points Claude at the context folder |
 | Cursor | Creates `.cursor/rules/memex.mdc` | Points Cursor at the context folder |
 | Gemini | Creates/appends to `GEMINI.md` | Points Gemini at the context folder |
 
 Also writes:
-- `.context/compact_prompt.md` -- a compaction policy that teaches agents to compress context while leaving search keys pointing back to `.context/sessions/`
+- `.context/compact_prompt.md` -- a shared compaction policy that teaches agents to compress context while leaving search keys pointing back to `.context/sessions/`
+- `.codex/compact_prompt.md` -- a Codex-local copy so Codex startup does not depend on `.context/compact_prompt.md` staying present
 - `.context/LEARNINGS.md` -- a shared file where agents append decisions, pitfalls, and patterns
 - `.gitignore` entries for `.context/sessions/*.md` and `.context/LEARNINGS.md` (local plaintext only; share via `vault.age`)
 - A local-only repo-root alias list under `.context/.memex/` so renames/moves don't break `memex sync` (gitignored via `.git/info/exclude`)
@@ -167,7 +168,7 @@ Looking at core_daemon/src/main.rs, you spawn a new task...
 
 ## Compact prompt
 
-`.context/compact_prompt.md` is a compaction policy. For Codex, it's automatically wired via `.codex/config.toml`. For other agents, it's a reference document -- you can tell the agent "use `.context/compact_prompt.md` when compressing context."
+`.context/compact_prompt.md` is the shared compaction policy. For Codex, `memex init` also writes a repo-local copy at `.codex/compact_prompt.md` and wires that through `.codex/config.toml`, so Codex does not break if `.context/compact_prompt.md` gets removed. For other agents, `.context/compact_prompt.md` remains the reference document -- you can tell the agent "use `.context/compact_prompt.md` when compressing context."
 
 The prompt teaches the agent to preserve search keys pointing back to `.context/sessions/` when compacting, so detail can be recovered later by grepping the archive.
 

--- a/tools/memex/src/init.rs
+++ b/tools/memex/src/init.rs
@@ -49,6 +49,12 @@ pitfalls, and patterns to .context/LEARNINGS.md.
 Run `memex sync` if sessions look stale.
 "#;
 
+const CODEX_COMPACT_PROMPT_FILE: &str = "compact_prompt.md";
+const CODEX_COMPACT_CONFIG_KEY: &str = "experimental_compact_prompt_file";
+const CODEX_COMPACT_CONFIG_LINE: &str = "experimental_compact_prompt_file = \"compact_prompt.md\"";
+const LEGACY_CODEX_COMPACT_CONFIG_LINE: &str =
+    "experimental_compact_prompt_file = \"../.context/compact_prompt.md\"";
+
 pub fn run_init(repo_root: &Path) -> Result<()> {
     let repo_roots = aliases::load_repo_roots(repo_root);
     let agents = detect::detect_agents(&repo_roots);
@@ -104,11 +110,16 @@ fn write_agent_files(repo_root: &Path, agents: &DetectedAgents) -> Result<()> {
         let agents_md = repo_root.join("AGENTS.md");
         append_section_if_missing(&agents_md, AGENT_INSTRUCTION, AGENT_MARKER)?;
 
-        // Write .codex/config.toml entry for compact prompt
         let codex_dir = repo_root.join(".codex");
         fs::create_dir_all(&codex_dir)?;
+        let codex_compact_path = codex_dir.join(CODEX_COMPACT_PROMPT_FILE);
+        write_if_missing(
+            &codex_compact_path,
+            COMPACT_PROMPT,
+            ".codex/compact_prompt.md",
+        )?;
         let codex_config = codex_dir.join("config.toml");
-        append_codex_compact_config(&codex_config)?;
+        ensure_codex_compact_config(&codex_config)?;
     }
 
     // Claude Code: CLAUDE.md
@@ -169,25 +180,58 @@ fn append_section_if_missing(path: &Path, section: &str, marker: &str) -> Result
     Ok(())
 }
 
-fn append_codex_compact_config(config_path: &Path) -> Result<()> {
-    let compact_line = "experimental_compact_prompt_file = \"../.context/compact_prompt.md\"";
-
+fn ensure_codex_compact_config(config_path: &Path) -> Result<()> {
     if config_path.exists() {
         let existing = fs::read_to_string(config_path)?;
-        if existing.contains("experimental_compact_prompt_file") {
+        if existing.contains(CODEX_COMPACT_CONFIG_LINE) {
             println!("  skip .codex/config.toml (compact prompt already configured)");
             return Ok(());
         }
+
+        let mut patched_lines = Vec::new();
+        let mut saw_compact_key = false;
+        let mut patched_legacy_path = false;
+
+        for line in existing.lines() {
+            if line.trim() == LEGACY_CODEX_COMPACT_CONFIG_LINE {
+                patched_lines.push(CODEX_COMPACT_CONFIG_LINE.to_string());
+                saw_compact_key = true;
+                patched_legacy_path = true;
+                continue;
+            }
+
+            if line.trim_start().starts_with(CODEX_COMPACT_CONFIG_KEY) {
+                saw_compact_key = true;
+            }
+
+            patched_lines.push(line.to_string());
+        }
+
+        if patched_legacy_path {
+            let mut content = patched_lines.join("\n");
+            if existing.ends_with('\n') {
+                content.push('\n');
+            }
+            fs::write(config_path, content)?;
+            println!("  patched .codex/config.toml (migrated compact prompt path)");
+            return Ok(());
+        }
+
+        if saw_compact_key {
+            println!("  skip .codex/config.toml (custom compact prompt already configured)");
+            return Ok(());
+        }
+
         let mut content = existing;
         if !content.ends_with('\n') {
             content.push('\n');
         }
-        content.push_str(compact_line);
+        content.push_str(CODEX_COMPACT_CONFIG_LINE);
         content.push('\n');
         fs::write(config_path, content)?;
         println!("  patched .codex/config.toml (added compact prompt path)");
     } else {
-        fs::write(config_path, format!("{compact_line}\n"))?;
+        fs::write(config_path, format!("{CODEX_COMPACT_CONFIG_LINE}\n"))?;
         println!("  wrote .codex/config.toml");
     }
     Ok(())
@@ -394,7 +438,10 @@ fn print_summary(repo_root: &Path, agents: &DetectedAgents) {
 
 #[cfg(test)]
 mod tests {
-    use super::{install_single_hook, PRE_COMMIT_HOOK_MARKER, PRE_COMMIT_HOOK_SCRIPT};
+    use super::{
+        ensure_codex_compact_config, install_single_hook, CODEX_COMPACT_CONFIG_LINE,
+        LEGACY_CODEX_COMPACT_CONFIG_LINE, PRE_COMMIT_HOOK_MARKER, PRE_COMMIT_HOOK_SCRIPT,
+    };
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -420,6 +467,41 @@ mod tests {
         assert!(content.contains(PRE_COMMIT_HOOK_MARKER));
 
         let _ = fs::remove_dir_all(hooks_dir);
+    }
+
+    #[test]
+    fn ensure_codex_compact_config_migrates_legacy_context_path() {
+        let dir = create_temp_hooks_dir("codex-config-legacy");
+        let config_path = dir.join("config.toml");
+        fs::write(
+            &config_path,
+            format!("{LEGACY_CODEX_COMPACT_CONFIG_LINE}\n"),
+        )
+        .unwrap();
+
+        ensure_codex_compact_config(&config_path).unwrap();
+
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains(CODEX_COMPACT_CONFIG_LINE));
+        assert!(!content.contains(LEGACY_CODEX_COMPACT_CONFIG_LINE));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn ensure_codex_compact_config_preserves_custom_path() {
+        let dir = create_temp_hooks_dir("codex-config-custom");
+        let config_path = dir.join("config.toml");
+        let custom_line = "experimental_compact_prompt_file = \"/tmp/custom-prompt.md\"";
+        fs::write(&config_path, format!("{custom_line}\n")).unwrap();
+
+        ensure_codex_compact_config(&config_path).unwrap();
+
+        let content = fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains(custom_line));
+        assert!(!content.contains(CODEX_COMPACT_CONFIG_LINE));
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     fn create_temp_hooks_dir(label: &str) -> PathBuf {

--- a/tools/wrapup/Cargo.toml
+++ b/tools/wrapup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapup"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Contrail year-in-code report generator"
 license = "MIT"
@@ -9,7 +9,7 @@ repository = "https://github.com/strangeloopcanon/contrail"
 [dependencies]
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-contrail-types = { path = "../../contrail_types", version = "0.1.3" }
+contrail-types = { path = "../../contrail_types", version = "0.1.4" }
 dirs = "5.0.1"
 reqwest = { version = "0.12.4", features = ["blocking", "json", "rustls-tls"] }
 rusqlite = { version = "0.31.0", features = ["bundled"] }


### PR DESCRIPTION
## Summary
- move Codex compact prompt wiring to a repo-local `.codex/compact_prompt.md` file
- migrate legacy memex-managed Codex configs while preserving custom compact prompt paths
- bump workspace package versions and document the safer setup in the memex README

## Why
Older memex-initialized repos pointed Codex at `../.context/compact_prompt.md`, which could break Codex startup if the `.context` file was missing. This change keeps the configured prompt file next to `.codex/config.toml` and heals the old path on re-init.

## Validation
- `make check`
- `make test`