### PR TITLE
chore: refresh beads metadata for bd 0.59

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,29 +1,51 @@
-# SQLite databases
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+dolt-monitor.pid
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Legacy files (from pre-Dolt versions)
 *.db
 *.db?*
 *.db-journal
 *.db-wal
 *.db-shm
-
-# Daemon runtime files
-daemon.lock
-daemon.log
-daemon.pid
-bd.sock
-
-# Legacy database files
 db.sqlite
 bd.db
-
-# Merge artifacts (temporary files from 3-way merge)
-beads.base.jsonl
-beads.base.meta.json
-beads.left.jsonl
-beads.left.meta.json
-beads.right.jsonl
-beads.right.meta.json
-
-# Keep JSONL exports and config (source of truth for git)
-!issues.jsonl
-!metadata.json
-!config.json
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,4 +1,7 @@
 {
-  "database": "beads.db",
-  "jsonl_export": "issues.jsonl"
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "contrail",
+  "project_id": "4d3d69d5-65c6-4562-b44f-47499ebc2ac1"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ export/wrapup_*.json
 .context/LEARNINGS.md
 # Rust formatter backups
 **/*.rs.bk
+
+# Dolt database files (added by bd init)
+.dolt/
+*.db


### PR DESCRIPTION
## Summary
- refresh tracked Beads metadata to the current Dolt-backed layout expected by `bd 0.59`
- update the tracked `.beads/.gitignore` entries to match modern Beads runtime artifacts
- add the recommended root `.gitignore` Dolt patterns

## Why
Updating the local Beads CLI to the current official release surfaced that this repo still had legacy SQLite-era Beads metadata. This small follow-up keeps the repo metadata aligned with the current tool so local `bd` health checks pass cleanly after upgrade.

## Validation
- `bd doctor`
- `bd doctor --check-health`