### PR TITLE
fix: harden contrail runtime safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,13 @@ Each machine builds its own log. To combine them:
 contrail export-log -o ~/Desktop/contrail-export.jsonl
 
 # Machine B: merge (stop daemon first)
+contrail down
 contrail merge-log ~/Desktop/contrail-export.jsonl
 ```
 
 Re-running merge is safe -- it deduplicates by event ID and content fingerprint.
+`merge-log` refuses to run while the Contrail daemon is active through either
+the macOS LaunchAgent or `contrail up`.
 
 ## Privacy
 

--- a/analysis/src/ingest.rs
+++ b/analysis/src/ingest.rs
@@ -8,12 +8,21 @@ use regex::Regex;
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 use std::path::Path;
 use std::path::PathBuf;
 
 pub fn load_dataset(log_path: &Path, day_filter: Option<NaiveDate>) -> Result<Dataset> {
-    let file = File::open(log_path).context("open master_log.jsonl")?;
+    let file = match File::open(log_path) {
+        Ok(file) => file,
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            return Ok(Dataset {
+                sessions: Vec::new(),
+                day_filter,
+            });
+        }
+        Err(e) => return Err(e).context("open master_log.jsonl"),
+    };
     let reader = BufReader::new(file);
     let mut logs = Vec::new();
 
@@ -359,4 +368,22 @@ fn project_root_from_path(raw: &str) -> Option<String> {
     }
 
     Some(path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_dataset;
+
+    #[test]
+    fn load_dataset_treats_missing_log_as_empty_dataset() {
+        let path = std::env::temp_dir().join(format!(
+            "contrail-analysis-missing-log-{}-{}.jsonl",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+
+        let dataset = load_dataset(&path, None).expect("missing log should be readable as empty");
+        assert!(dataset.sessions.is_empty());
+        assert!(dataset.day_filter.is_none());
+    }
 }

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -175,27 +175,13 @@ const DEFAULT_PROBES: &[&str] = &[
 ];
 
 pub async fn run() -> anyhow::Result<()> {
-    let log_path = env::var("CONTRAIL_LOG_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .expect("Could not find home directory")
-                .join(".contrail/logs/master_log.jsonl")
-        });
-    let memory_path = env::var("CONTRAIL_MEMORY_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .expect("Could not find home directory")
-                .join(".contrail/analysis/memories.jsonl")
-        });
-    let memory_blocks_path = env::var("CONTRAIL_MEMORY_BLOCKS_PATH")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            dirs::home_dir()
-                .expect("Could not find home directory")
-                .join(".contrail/analysis/memory_blocks.json")
-        });
+    let log_path = env_path_or_home("CONTRAIL_LOG_PATH", ".contrail/logs/master_log.jsonl")?;
+    let memory_path =
+        env_path_or_home("CONTRAIL_MEMORY_PATH", ".contrail/analysis/memories.jsonl")?;
+    let memory_blocks_path = env_path_or_home(
+        "CONTRAIL_MEMORY_BLOCKS_PATH",
+        ".contrail/analysis/memory_blocks.json",
+    )?;
 
     let initial_dataset = ingest::load_dataset(&log_path, None)?;
     let state = AppState {
@@ -246,6 +232,15 @@ pub async fn run() -> anyhow::Result<()> {
 
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
+}
+
+fn env_path_or_home(key: &str, home_relative: &str) -> anyhow::Result<PathBuf> {
+    if let Ok(value) = env::var(key) {
+        return Ok(PathBuf::from(value));
+    }
+
+    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not find home directory"))?;
+    Ok(home.join(home_relative))
 }
 
 async fn index() -> Html<&'static str> {

--- a/contrails/src/bin/dashboard.rs
+++ b/contrails/src/bin/dashboard.rs
@@ -1,4 +1,4 @@
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     contrail_dashboard::run().await
 }

--- a/core_daemon/src/lib.rs
+++ b/core_daemon/src/lib.rs
@@ -148,9 +148,11 @@ pub async fn run() -> anyhow::Result<()> {
     claude_handle.abort();
     claude_projects_handle.abort();
 
-    drop(harvester);
+    if let Err(e) = harvester.flush_logs().await {
+        warn!(err = ?e, "failed to flush log writer during shutdown");
+    }
 
-    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    drop(harvester);
 
     info!("contrail daemon stopped");
     Ok(())

--- a/dashboard/src/lib.rs
+++ b/dashboard/src/lib.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::env;
 use std::fs::File;
-use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::io::{BufRead, ErrorKind, Read, Seek, SeekFrom};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
@@ -25,12 +25,17 @@ use tokio::{
 };
 use tower_http::cors::CorsLayer;
 
-pub async fn run() {
+pub async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let log_path = env::var("CONTRAIL_LOG_PATH")
         .map(PathBuf::from)
         .ok()
         .or_else(|| dirs::home_dir().map(|h| h.join(".contrail/logs/master_log.jsonl")))
-        .expect("Could not resolve CONTRAIL_LOG_PATH or home directory");
+        .ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::NotFound,
+                "could not resolve CONTRAIL_LOG_PATH or home directory",
+            )
+        })?;
 
     let (live_tx, _) = broadcast::channel(2048);
     let state = Arc::new(AppState {
@@ -50,11 +55,11 @@ pub async fn run() {
 
     let bind_addr = env::var("DASHBOARD_BIND").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     println!("✈️  Contrail Dashboard running at http://{bind_addr}");
-    let listener = tokio::net::TcpListener::bind(&bind_addr).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
-        .await
-        .unwrap();
+        .await?;
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -336,19 +341,13 @@ fn load_tail_logs(
 
 fn matches_filters(json: &Value, tool: Option<&str>, session_id: Option<&str>) -> bool {
     if let Some(tool_filter) = tool
-        && json
-            .get("source_tool")
-            .and_then(Value::as_str)
-            .is_some_and(|t| t != tool_filter)
+        && json.get("source_tool").and_then(Value::as_str) != Some(tool_filter)
     {
         return false;
     }
 
     if let Some(session_filter) = session_id
-        && json
-            .get("session_id")
-            .and_then(Value::as_str)
-            .is_some_and(|s| s != session_filter)
+        && json.get("session_id").and_then(Value::as_str) != Some(session_filter)
     {
         return false;
     }
@@ -457,4 +456,40 @@ struct StreamQuery {
 
 async fn shutdown_signal() {
     let _ = tokio::signal::ctrl_c().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_filters;
+    use serde_json::json;
+
+    #[test]
+    fn tool_filter_rejects_missing_or_different_tool() {
+        assert!(matches_filters(
+            &json!({"source_tool": "codex-cli"}),
+            Some("codex-cli"),
+            None,
+        ));
+        assert!(!matches_filters(
+            &json!({"source_tool": "cursor"}),
+            Some("codex-cli"),
+            None,
+        ));
+        assert!(!matches_filters(&json!({}), Some("codex-cli"), None));
+    }
+
+    #[test]
+    fn session_filter_rejects_missing_or_different_session() {
+        assert!(matches_filters(
+            &json!({"session_id": "s1"}),
+            None,
+            Some("s1"),
+        ));
+        assert!(!matches_filters(
+            &json!({"session_id": "s2"}),
+            None,
+            Some("s1"),
+        ));
+        assert!(!matches_filters(&json!({}), None, Some("s1")));
+    }
 }

--- a/dashboard/src/main.rs
+++ b/dashboard/src/main.rs
@@ -1,4 +1,4 @@
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     contrail_dashboard::run().await
 }

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -7,9 +7,11 @@ use scrapers::claude_profile_import::{
 use scrapers::config::ContrailConfig;
 use scrapers::history_import;
 use scrapers::merge::{self, ExportFilters};
-use std::path::PathBuf;
-#[cfg(target_os = "macos")]
-use std::process::Command;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::{Command, Stdio};
 
 #[derive(Parser)]
 #[command(
@@ -182,7 +184,7 @@ fn run_merge(file: PathBuf) -> Result<()> {
     let config = ContrailConfig::from_env()?;
 
     if is_contrail_daemon_running() {
-        anyhow::bail!("com.contrail.daemon is running; stop it before merge");
+        anyhow::bail!("contrail daemon is running; stop it before merge");
     }
 
     println!(
@@ -324,8 +326,59 @@ fn parse_optional_ts(value: Option<&str>, flag_name: &str) -> Result<Option<Date
     }
 }
 
-#[cfg(target_os = "macos")]
 fn is_contrail_daemon_running() -> bool {
+    is_managed_core_daemon_running() || is_launch_agent_running()
+}
+
+fn is_managed_core_daemon_running() -> bool {
+    let Some(run_dir) = contrail_run_dir() else {
+        return false;
+    };
+    is_managed_core_daemon_running_in(&run_dir)
+}
+
+fn is_managed_core_daemon_running_in(run_dir: &Path) -> bool {
+    let pid_path = run_dir.join("core_daemon.pid");
+    read_pid(&pid_path).is_some_and(is_pid_running)
+}
+
+fn contrail_run_dir() -> Option<PathBuf> {
+    if let Some(root) = env::var_os("CONTRAIL_HOME") {
+        return Some(PathBuf::from(root).join("run"));
+    }
+
+    env::var_os("HOME").map(|home| PathBuf::from(home).join(".contrail/run"))
+}
+
+fn read_pid(pid_path: &Path) -> Option<u32> {
+    let raw = fs::read_to_string(pid_path).ok()?;
+    parse_pid(&raw)
+}
+
+fn parse_pid(raw: &str) -> Option<u32> {
+    let pid = raw.trim().parse::<u32>().ok()?;
+    (pid > 0).then_some(pid)
+}
+
+#[cfg(unix)]
+fn is_pid_running(pid: u32) -> bool {
+    Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_pid_running(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn is_launch_agent_running() -> bool {
     Command::new("launchctl")
         .arg("list")
         .arg("com.contrail.daemon")
@@ -335,7 +388,7 @@ fn is_contrail_daemon_running() -> bool {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn is_contrail_daemon_running() -> bool {
+fn is_launch_agent_running() -> bool {
     false
 }
 
@@ -354,6 +407,45 @@ mod tests {
         let err = parse_optional_ts(Some("not-a-timestamp"), "--after").unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("invalid --after timestamp"));
+    }
+
+    #[test]
+    fn parse_pid_accepts_trimmed_positive_pid() {
+        assert_eq!(parse_pid(" 12345\n"), Some(12345));
+    }
+
+    #[test]
+    fn parse_pid_rejects_invalid_or_zero_pid() {
+        assert_eq!(parse_pid("not-a-pid"), None);
+        assert_eq!(parse_pid("0"), None);
+        assert_eq!(parse_pid(""), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_daemon_check_detects_running_pid_file() {
+        let run_dir = temp_run_dir("running-pid");
+        fs::create_dir_all(&run_dir).unwrap();
+        fs::write(
+            run_dir.join("core_daemon.pid"),
+            format!("{}\n", std::process::id()),
+        )
+        .unwrap();
+
+        assert!(is_managed_core_daemon_running_in(&run_dir));
+
+        let _ = fs::remove_dir_all(run_dir);
+    }
+
+    #[test]
+    fn managed_daemon_check_ignores_invalid_pid_file() {
+        let run_dir = temp_run_dir("invalid-pid");
+        fs::create_dir_all(&run_dir).unwrap();
+        fs::write(run_dir.join("core_daemon.pid"), "not-a-pid\n").unwrap();
+
+        assert!(!is_managed_core_daemon_running_in(&run_dir));
+
+        let _ = fs::remove_dir_all(run_dir);
     }
 
     #[test]
@@ -396,5 +488,16 @@ mod tests {
             panic!("expected import-claude");
         };
         assert!(dry_run);
+    }
+
+    fn temp_run_dir(label: &str) -> PathBuf {
+        let mut dir = env::temp_dir();
+        dir.push(format!(
+            "contrail-importer-tests-{}-{}-{}",
+            label,
+            std::process::id(),
+            Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        ));
+        dir
     }
 }

--- a/scrapers/src/log_writer.rs
+++ b/scrapers/src/log_writer.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::types::MasterLog;
 
@@ -9,12 +9,17 @@ const CHANNEL_CAPACITY: usize = 1024;
 
 #[derive(Clone)]
 pub struct LogWriter {
-    sender: mpsc::Sender<MasterLog>,
+    sender: mpsc::Sender<LogWriterCommand>,
+}
+
+enum LogWriterCommand {
+    Write(Box<MasterLog>),
+    Flush(oneshot::Sender<Result<(), String>>),
 }
 
 impl LogWriter {
     pub fn new(log_path: PathBuf) -> Self {
-        let (sender, mut receiver) = mpsc::channel::<MasterLog>(CHANNEL_CAPACITY);
+        let (sender, mut receiver) = mpsc::channel::<LogWriterCommand>(CHANNEL_CAPACITY);
 
         tokio::spawn(async move {
             if let Err(e) = async move {
@@ -25,11 +30,20 @@ impl LogWriter {
                     .await
                     .with_context(|| format!("failed to open log file at {:?}", log_path))?;
 
-                while let Some(log) = receiver.recv().await {
-                    let mut line = serde_json::to_vec(&log)?;
-                    line.push(b'\n');
-                    file.write_all(&line).await?;
+                while let Some(command) = receiver.recv().await {
+                    match command {
+                        LogWriterCommand::Write(log) => {
+                            let mut line = serde_json::to_vec(&log)?;
+                            line.push(b'\n');
+                            file.write_all(&line).await?;
+                        }
+                        LogWriterCommand::Flush(done) => {
+                            let result = file.flush().await.map_err(|e| e.to_string());
+                            let _ = done.send(result);
+                        }
+                    }
                 }
+                file.flush().await?;
                 Ok::<_, anyhow::Error>(())
             }
             .await
@@ -43,8 +57,65 @@ impl LogWriter {
 
     pub async fn write(&self, log: MasterLog) -> Result<()> {
         self.sender
-            .send(log)
+            .send(LogWriterCommand::Write(Box::new(log)))
             .await
             .map_err(|_| anyhow::anyhow!("log writer channel closed"))
+    }
+
+    pub async fn flush(&self) -> Result<()> {
+        let (done_tx, done_rx) = oneshot::channel();
+        self.sender
+            .send(LogWriterCommand::Flush(done_tx))
+            .await
+            .map_err(|_| anyhow::anyhow!("log writer channel closed"))?;
+
+        match done_rx.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(anyhow::anyhow!("log writer flush failed: {e}")),
+            Err(_) => Err(anyhow::anyhow!("log writer flush was cancelled")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Interaction, MasterLog};
+    use chrono::Utc;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn flush_waits_for_queued_writes() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let log_path = dir.path().join("master_log.jsonl");
+        let writer = LogWriter::new(log_path.clone());
+
+        writer.write(test_log("hello")).await?;
+        writer.flush().await?;
+
+        let content = tokio::fs::read_to_string(&log_path).await?;
+        assert!(content.contains("hello"));
+        Ok(())
+    }
+
+    fn test_log(content: &str) -> MasterLog {
+        MasterLog {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            source_tool: "test".to_string(),
+            project_context: "/tmp/project".to_string(),
+            session_id: "session".to_string(),
+            interaction: Interaction {
+                role: "user".to_string(),
+                content: content.to_string(),
+                artifacts: None,
+            },
+            security_flags: contrail_types::SecurityFlags {
+                has_pii: false,
+                redacted_secrets: Vec::new(),
+            },
+            metadata: json!({}),
+        }
     }
 }

--- a/scrapers/src/merge.rs
+++ b/scrapers/src/merge.rs
@@ -5,13 +5,15 @@
 //! then by a content fingerprint to catch the same underlying event ingested independently
 //! on two machines (which would have different UUIDs).
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 use uuid::Uuid;
 
@@ -49,6 +51,12 @@ pub fn export_log(log_path: &Path, filters: &ExportFilters, output: &Path) -> Re
     let file = File::open(log_path)
         .with_context(|| format!("open master log at {}", log_path.display()))?;
     let reader = BufReader::new(file);
+
+    ensure!(
+        !paths_refer_to_same_file(log_path, output)?,
+        "refusing to export over source log: {}",
+        output.display()
+    );
 
     if let Some(parent) = output.parent() {
         fs::create_dir_all(parent)?;
@@ -92,15 +100,16 @@ pub fn export_log(log_path: &Path, filters: &ExportFilters, output: &Path) -> Re
 }
 
 fn matches_filters(json: &Value, f: &ExportFilters) -> bool {
-    if let Some(ref after) = f.after {
-        if let Some(ts) = parse_timestamp(json) {
+    if f.after.is_some() || f.before.is_some() {
+        let Some(ts) = parse_timestamp(json) else {
+            return false;
+        };
+        if let Some(ref after) = f.after {
             if ts < *after {
                 return false;
             }
         }
-    }
-    if let Some(ref before) = f.before {
-        if let Some(ts) = parse_timestamp(json) {
+        if let Some(ref before) = f.before {
             if ts >= *before {
                 return false;
             }
@@ -306,6 +315,31 @@ fn write_jsonl_line<W: Write>(writer: &mut W, line: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn paths_refer_to_same_file(left: &Path, right: &Path) -> Result<bool> {
+    let left_meta = fs::metadata(left).with_context(|| format!("stat {}", left.display()))?;
+    let right_meta = match fs::metadata(right) {
+        Ok(meta) => meta,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e).with_context(|| format!("stat {}", right.display())),
+    };
+
+    Ok(left_meta.dev() == right_meta.dev() && left_meta.ino() == right_meta.ino())
+}
+
+#[cfg(not(unix))]
+fn paths_refer_to_same_file(left: &Path, right: &Path) -> Result<bool> {
+    if !right.exists() {
+        return Ok(false);
+    }
+
+    let left =
+        fs::canonicalize(left).with_context(|| format!("canonicalize {}", left.display()))?;
+    let right =
+        fs::canonicalize(right).with_context(|| format!("canonicalize {}", right.display()))?;
+    Ok(left == right)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -487,6 +521,20 @@ mod tests {
     }
 
     #[test]
+    fn export_rejects_output_path_that_is_source_log() {
+        let event = make_event(Uuid::new_v4(), "cursor", "s1", "preserve me", "macA");
+        let log_file = write_events(&[event]);
+        let before = fs::read_to_string(log_file.path()).unwrap();
+
+        let err = export_log(log_file.path(), &ExportFilters::default(), log_file.path())
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("refusing to export over source log"));
+        assert_eq!(fs::read_to_string(log_file.path()).unwrap(), before);
+    }
+
+    #[test]
     fn export_filters_by_date_range() {
         let ts_old = "2024-01-01T00:00:00Z";
         let ts_new = "2026-06-01T00:00:00Z";
@@ -505,6 +553,26 @@ mod tests {
         let stats = export_log(log_file.path(), &filters, output.path()).unwrap();
         assert_eq!(stats.exported, 1);
         assert_eq!(stats.skipped, 1);
+    }
+
+    #[test]
+    fn export_date_filter_rejects_missing_or_invalid_timestamp() {
+        let mut missing = make_event(Uuid::new_v4(), "cursor", "s1", "missing", "macA");
+        missing.as_object_mut().unwrap().remove("timestamp");
+        let mut invalid = make_event(Uuid::new_v4(), "cursor", "s2", "invalid", "macA");
+        invalid["timestamp"] = json!("not-a-timestamp");
+        let valid = make_event(Uuid::new_v4(), "cursor", "s3", "valid", "macA");
+
+        let log_file = write_events(&[missing, invalid, valid]);
+        let output = tempfile::NamedTempFile::new().unwrap();
+        let filters = ExportFilters {
+            after: Some("2020-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap()),
+            ..Default::default()
+        };
+
+        let stats = export_log(log_file.path(), &filters, output.path()).unwrap();
+        assert_eq!(stats.exported, 1);
+        assert_eq!(stats.skipped, 2);
     }
 
     #[test]

--- a/scrapers/src/watchers/mod.rs
+++ b/scrapers/src/watchers/mod.rs
@@ -95,4 +95,8 @@ impl Harvester {
         self.log_writer.write(log).await?;
         Ok(())
     }
+
+    pub async fn flush_logs(&self) -> Result<()> {
+        self.log_writer.flush().await
+    }
 }

--- a/tools/contrail/src/lib.rs
+++ b/tools/contrail/src/lib.rs
@@ -219,13 +219,12 @@ fn stop_process(run_dir: &Path, process: ManagedProcess) -> Result<()> {
         return Ok(());
     }
 
-    let _ = send_signal(pid, None)?;
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline {
-        if !is_pid_running(pid) {
-            break;
-        }
-        thread::sleep(Duration::from_millis(100));
+    let _ = send_signal(pid, Some("-INT"))?;
+    wait_until_stopped(pid, Duration::from_secs(5));
+
+    if is_pid_running(pid) {
+        let _ = send_signal(pid, None)?;
+        wait_until_stopped(pid, Duration::from_secs(2));
     }
 
     if is_pid_running(pid) {
@@ -258,7 +257,12 @@ fn print_process_status(run_dir: &Path, process: ManagedProcess) {
 
 fn read_pid(pid_path: &Path) -> Option<u32> {
     let raw = fs::read_to_string(pid_path).ok()?;
-    raw.trim().parse::<u32>().ok()
+    parse_pid(&raw)
+}
+
+fn parse_pid(raw: &str) -> Option<u32> {
+    let pid = raw.trim().parse::<u32>().ok()?;
+    (pid > 0).then_some(pid)
 }
 
 fn is_pid_running(pid: u32) -> bool {
@@ -284,6 +288,16 @@ fn send_signal(pid: u32, signal: Option<&str>) -> Result<bool> {
         .status()
         .with_context(|| format!("failed to send signal to pid {}", pid))?;
     Ok(status.success())
+}
+
+fn wait_until_stopped(pid: u32, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !is_pid_running(pid) {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
 fn wait_for_health(name: &str, addr: &str) -> bool {
@@ -323,7 +337,7 @@ fn resolve_binary_path(process: ManagedProcess) -> Result<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{LifecycleCommand, parse_lifecycle_command};
+    use super::{LifecycleCommand, parse_lifecycle_command, parse_pid};
     use std::ffi::OsString;
 
     #[test]
@@ -351,5 +365,17 @@ mod tests {
     fn leaves_other_commands_for_importer_cli() {
         let args = vec![OsString::from("contrail"), OsString::from("import-history")];
         assert!(parse_lifecycle_command(&args).is_none());
+    }
+
+    #[test]
+    fn parse_pid_accepts_trimmed_positive_pid() {
+        assert_eq!(parse_pid(" 42\n"), Some(42));
+    }
+
+    #[test]
+    fn parse_pid_rejects_invalid_or_zero_pid() {
+        assert_eq!(parse_pid("not-a-pid"), None);
+        assert_eq!(parse_pid("0"), None);
+        assert_eq!(parse_pid(""), None);
     }
 }


### PR DESCRIPTION
## Summary

Hardens Contrail's local runtime and import/export paths:

- blocks `merge-log` while the daemon is active through either LaunchAgent or `contrail up`
- prevents `export-log` from overwriting its own source log
- flushes queued daemon log writes during graceful shutdown
- makes `contrail down` send SIGINT before TERM/SIGKILL fallback
- makes dashboard and analysis startup fail cleanly instead of panicking
- tightens dashboard and export filter behavior for missing fields or invalid timestamps
- documents stopping the daemon before cross-machine merge

## Validation

- `make check`
- `make test`
- `git diff --check`